### PR TITLE
COM Temp group & Kinetic Energy computation

### DIFF
--- a/openmmapi/include/openmm/DrudeNoseHooverIntegrator.h
+++ b/openmmapi/include/openmm/DrudeNoseHooverIntegrator.h
@@ -301,7 +301,7 @@ protected:
 private:
     double temperature, couplingTime, drudeTemperature, drudeCouplingTime, maxDrudeDistance;
     int drudeStepsPerRealStep, numNHChains, numTempGroups;
-    bool useDrudeNHChains,useCOMTempGroup;
+    bool useDrudeNHChains,useCOMTempGroup,hasBarostat;
     std::vector<int> particleTempGroup;
     std::vector<int> tempGroups;
     std::vector<int> particleResId;

--- a/openmmapi/include/openmm/DrudeNoseHooverIntegrator.h
+++ b/openmmapi/include/openmm/DrudeNoseHooverIntegrator.h
@@ -301,7 +301,7 @@ protected:
 private:
     double temperature, couplingTime, drudeTemperature, drudeCouplingTime, maxDrudeDistance;
     int drudeStepsPerRealStep, numNHChains, numTempGroups;
-    bool useDrudeNHChains,useCOMTempGroup,hasBarostat;
+    bool useDrudeNHChains,useCOMTempGroup,hasBarostat,isKESumValid;
     std::vector<int> particleTempGroup;
     std::vector<int> tempGroups;
     std::vector<int> particleResId;

--- a/openmmapi/include/openmm/DrudeNoseHooverIntegrator.h
+++ b/openmmapi/include/openmm/DrudeNoseHooverIntegrator.h
@@ -66,6 +66,7 @@ public:
      * @param drudeStepsPerRealStep the number of steps with which to integrator the drude particles per single step (integer)
      * @param numNHChains    the number of Nose-Hoover chains (integer)
      * @param useDrudeNHChains    whether to use the NH-Chain for the drude d.o.f. (bool)
+     * @param useCOMTempGroup    whether to use the NH-Chain for the drude d.o.f. (bool)
      */
     DrudeNoseHooverIntegrator(double temperature, double couplingTime, double drudeTemperature, double drudeCouplingTime, double stepSize, int drudeStepsPerRealStep=20, int numNHChains=1, bool useDrudeNHChains=true, bool useCOMTempGroup=true);
     /**
@@ -205,7 +206,7 @@ public:
      *
      * @return whether to use COM Temperature group
      */
-    int getUseCOMTempGroup() const {
+    bool getUseCOMTempGroup() const {
         return useCOMTempGroup;
     }
     /**

--- a/openmmapi/include/openmm/DrudeNoseKernels.h
+++ b/openmmapi/include/openmm/DrudeNoseKernels.h
@@ -70,7 +70,7 @@ public:
     /**
      * Compute the kinetic energy.
      */
-    virtual double computeKineticEnergy(ContextImpl& context, const DrudeNoseHooverIntegrator& integrator) = 0;
+    virtual double computeKineticEnergy(ContextImpl& context, const DrudeNoseHooverIntegrator& integrator, bool isKESumValid) = 0;
 };
 
 } // namespace OpenMM

--- a/openmmapi/src/DrudeNoseHooverIntegrator.cpp
+++ b/openmmapi/src/DrudeNoseHooverIntegrator.cpp
@@ -105,6 +105,7 @@ void DrudeNoseHooverIntegrator::initialize(ContextImpl& contextRef) {
         throw OpenMMException("This Integrator is already bound to a context");
     const DrudeForce* force = NULL;
     const System& system = contextRef.getSystem();
+    isKESumValid = false;
     hasBarostat = false;
     for (int i = 0; i < system.getNumForces(); i++) {
         if (dynamic_cast<const DrudeForce*>(&system.getForce(i)) != NULL) {
@@ -163,6 +164,7 @@ void DrudeNoseHooverIntegrator::cleanup() {
 }
 
 void DrudeNoseHooverIntegrator::stateChanged(State::DataType changed) {
+    isKESumValid = false;
     if (context != NULL)
         context->calcForcesAndEnergy(true, false);
 }
@@ -174,7 +176,7 @@ vector<string> DrudeNoseHooverIntegrator::getKernelNames() {
 }
 
 double DrudeNoseHooverIntegrator::computeKineticEnergy() {
-    return kernel.getAs<IntegrateDrudeNoseHooverStepKernel>().computeKineticEnergy(*context, *this);
+    return kernel.getAs<IntegrateDrudeNoseHooverStepKernel>().computeKineticEnergy(*context, *this, isKESumValid);
 }
 
 void DrudeNoseHooverIntegrator::step(int steps) {
@@ -196,5 +198,6 @@ void DrudeNoseHooverIntegrator::step(int steps) {
             context->updateContextState();
         }
         kernel.getAs<IntegrateDrudeNoseHooverStepKernel>().execute(*context, *this);
+        isKESumValid = true;
     }
 }

--- a/openmmapi/src/DrudeNoseHooverIntegrator.cpp
+++ b/openmmapi/src/DrudeNoseHooverIntegrator.cpp
@@ -38,6 +38,7 @@
 #include <ctime>
 #include <string>
 #include <iostream>
+#include <typeinfo>
 
 using namespace OpenMM;
 using std::string;
@@ -104,13 +105,20 @@ void DrudeNoseHooverIntegrator::initialize(ContextImpl& contextRef) {
         throw OpenMMException("This Integrator is already bound to a context");
     const DrudeForce* force = NULL;
     const System& system = contextRef.getSystem();
-    for (int i = 0; i < system.getNumForces(); i++)
+    hasBarostat = false;
+    for (int i = 0; i < system.getNumForces(); i++) {
         if (dynamic_cast<const DrudeForce*>(&system.getForce(i)) != NULL) {
             if (force == NULL)
                 force = dynamic_cast<const DrudeForce*>(&system.getForce(i));
             else
                 throw OpenMMException("The System contains multiple DrudeForces");
         }
+        std::string str(typeid(system.getForce(i)).name());
+        if (str.find("Baro") != std::string::npos) {
+            std::cout << typeid(system.getForce(i)).name() << "force group name\n";
+            hasBarostat = true;
+        }
+    }
     if (force == NULL)
         throw OpenMMException("The System does not contain a DrudeForce");
 
@@ -173,7 +181,20 @@ void DrudeNoseHooverIntegrator::step(int steps) {
     if (context == NULL)
         throw OpenMMException("This Integrator is not bound to a context!");    
     for (int i = 0; i < steps; ++i) {
-        context->updateContextState();
+        if (hasBarostat) {
+            Vec3 initialBox[3];
+            context->getPeriodicBoxVectors(initialBox[0], initialBox[1], initialBox[2]);
+            context->updateContextState();
+            Vec3 finalBox[3];
+            context->getPeriodicBoxVectors(finalBox[0], finalBox[1], finalBox[2]);
+            if (initialBox[0] != finalBox[0] || initialBox[1] != finalBox[1] || initialBox[2] != finalBox[2]) {
+                //std::cout << "#Box has changed ! recalculate force\n" << std::flush;
+                context->calcForcesAndEnergy(true, false);
+            }
+        }
+        else {
+            context->updateContextState();
+        }
         kernel.getAs<IntegrateDrudeNoseHooverStepKernel>().execute(*context, *this);
     }
 }

--- a/platforms/cuda/src/CudaDrudeNoseKernels.cpp
+++ b/platforms/cuda/src/CudaDrudeNoseKernels.cpp
@@ -340,7 +340,10 @@ void CudaIntegrateDrudeNoseHooverStepKernel::execute(ContextImpl& context, const
     //cout << "vscaleDrude at NHChain : " << vscaleDrude << "\n";
 
     //cout << "vscale : " << vscale << ", vscaleDrude : " << vscaleDrude << "\n";
-
+    if (cu.getAtomsWereReordered()) {
+        //cout << "#Atoms reordered ! recalculate Force ! \n" << flush;
+        context.calcForcesAndEnergy(true, false);
+    }
 
     bool updatePosDelta = false;
     void *updatePosDeltaPtr = &updatePosDelta;
@@ -641,5 +644,6 @@ std::vector<double> CudaIntegrateDrudeNoseHooverStepKernel::propagateNHChain(Con
 }
 
 double CudaIntegrateDrudeNoseHooverStepKernel::computeKineticEnergy(ContextImpl& context, const DrudeNoseHooverIntegrator& integrator) {
-    return cu.getIntegrationUtilities().computeKineticEnergy(0.5*integrator.getStepSize());
+    return cu.getIntegrationUtilities().computeKineticEnergy(0);
+    //return cu.getIntegrationUtilities().computeKineticEnergy(0.5*integrator.getStepSize());
 }

--- a/platforms/cuda/src/CudaDrudeNoseKernels.cpp
+++ b/platforms/cuda/src/CudaDrudeNoseKernels.cpp
@@ -126,7 +126,9 @@ void CudaIntegrateDrudeNoseHooverStepKernel::initialize(const System& system, co
         double resInvMass = integrator.getResInvMass(resid);
         if (mass != 0.0) {
             tempGroupDof[tg] += 3;
-            tempGroupRedMass[tg] += 3 * mass * resInvMass;
+            if (integrator.getUseCOMTempGroup()) {
+                tempGroupRedMass[tg] += 3 * mass * resInvMass;
+            }
         }
     }
     for (int i = 0; i < force.getNumParticles(); i++) {
@@ -191,7 +193,10 @@ void CudaIntegrateDrudeNoseHooverStepKernel::initialize(const System& system, co
 
         tempGroupDof[tg] -= 1;
     }
-    tempGroupDof[numTempGroups] = 3*integrator.getNumResidues();
+    if (integrator.getUseCOMTempGroup()) {
+        tempGroupDof[numTempGroups] = 3*integrator.getNumResidues();
+    }
+
     tempGroupDof[numTempGroups+1] = drudeDof;
 
     // Don't Ignore CM motion removal, which is small relative to the large d.o.f. for condensed phase

--- a/platforms/cuda/src/CudaDrudeNoseKernels.cpp
+++ b/platforms/cuda/src/CudaDrudeNoseKernels.cpp
@@ -235,6 +235,7 @@ void CudaIntegrateDrudeNoseHooverStepKernel::initialize(const System& system, co
     cout << "drude NkbT : " << drudeNkbT << "drudeQ0 : " << etaMass[itg][0] << ", drude Dof : " << tempGroupDof[itg] << "\n";
     cout << "Num NH Chain : " << integrator.getNumNHChains() << "\n";
     cout << "Use NH Chain for Drude dof : " << integrator.getUseDrudeNHChains() << "\n";
+    cout << "Use COM Temperature group : " << integrator.getUseCOMTempGroup() << "\n";
     cout << "real couplingTime : " << integrator.getCouplingTime() << "\n";
     cout << "drude couplingTime : " << integrator.getDrudeCouplingTime() << "\n";
 //    cout << "pair Particles[0].x : " << pairParticleVec[0].x << "\n";
@@ -457,7 +458,7 @@ std::vector<double> CudaIntegrateDrudeNoseHooverStepKernel::propagateNHChain(Con
     bool useCOMGroup = integrator.getUseCOMTempGroup();
     void *useCOMTempGroupPtr = &useCOMGroup;
     void* argsCOMVel[] = {&cu.getVelm().getDevicePointer(),
-            &particlesInResidues->getDevicePointer(), &comVelm->getDevicePointer(),&useCOMTempGroupPtr};
+            &particlesInResidues->getDevicePointer(), &comVelm->getDevicePointer(),useCOMTempGroupPtr};
 
     cu.executeKernel(kernelCOMVel, argsCOMVel, numResidues);
 

--- a/platforms/cuda/src/CudaDrudeNoseKernels.h
+++ b/platforms/cuda/src/CudaDrudeNoseKernels.h
@@ -66,15 +66,16 @@ public:
     /**
      * Compute the kinetic energy.
      * 
-     * @param context     the context in which to execute this kernel
-     * @param integrator  the DrudeNoseHooverIntegrator this kernel is being used for
+     * @param context       the context in which to execute this kernel
+     * @param integrator    the DrudeNoseHooverIntegrator this kernel is being used for
+     * @param isKESumValid  whether use saved KESum or calculate based on new velocities
      */
-    double computeKineticEnergy(ContextImpl& context, const DrudeNoseHooverIntegrator& integrator);
+    double computeKineticEnergy(ContextImpl& context, const DrudeNoseHooverIntegrator& integrator, bool isKESumValid);
 private:
     std::vector<double> propagateNHChain(ContextImpl& context, const DrudeNoseHooverIntegrator& integrator);
     void assignVscaleFactors();
     CudaContext& cu;
-    double prevStepSize, drudekbT, drudeNkbT, realkbT;
+    double prevStepSize, drudekbT, drudeNkbT, realkbT, KESum;
     int drudeDof, numResidues, numParticles;
     CudaArray* normalParticles;
     CudaArray* pairParticles;

--- a/platforms/reference/src/ReferenceDrudeNoseKernels.cpp
+++ b/platforms/reference/src/ReferenceDrudeNoseKernels.cpp
@@ -583,6 +583,6 @@ void ReferenceIntegrateDrudeNoseHooverStepKernel::propagateHalfVelocity(ContextI
     }
 }
 
-double ReferenceIntegrateDrudeNoseHooverStepKernel::computeKineticEnergy(ContextImpl& context, const DrudeNoseHooverIntegrator& integrator) {
+double ReferenceIntegrateDrudeNoseHooverStepKernel::computeKineticEnergy(ContextImpl& context, const DrudeNoseHooverIntegrator& integrator, bool isKESumValid) {
     return computeShiftedKineticEnergy(context, particleInvMass, 0.5*integrator.getStepSize());
 }

--- a/platforms/reference/src/ReferenceDrudeNoseKernels.h
+++ b/platforms/reference/src/ReferenceDrudeNoseKernels.h
@@ -70,10 +70,11 @@ public:
     /**
      * Compute the kinetic energy.
      * 
-     * @param context     the context in which to execute this kernel
-     * @param integrator  the DrudeNoseHooverIntegrator this kernel is being used for
+     * @param context       the context in which to execute this kernel
+     * @param integrator    the DrudeNoseHooverIntegrator this kernel is being used for
+     * @param isKESumValid  whether use saved KESum or calculate based on new velocities
      */
-    double computeKineticEnergy(ContextImpl& context, const DrudeNoseHooverIntegrator& integrator);
+    double computeKineticEnergy(ContextImpl& context, const DrudeNoseHooverIntegrator& integrator, bool isKESumValid);
 private:
     /**
      * Compute the kinetic energies for each degrees of freedom


### PR DESCRIPTION
Enable not using COM temperature group (For publication purpose)
Use same time stamp (half step in VV integrator) to calculate kinetic energy from velocities. This update makes the KE to be consistent with the potential energy.